### PR TITLE
Add rooms to backend

### DIFF
--- a/RESTAPI/ai/NewConversation.ts
+++ b/RESTAPI/ai/NewConversation.ts
@@ -8,6 +8,7 @@ const schema = z.object({
     .string()
     .min(1, 'Title is required')
     .max(100, 'Title must be less than 100 characters'),
+  room: z.number(),
 });
 
 const handler: RESTHandler = async (
@@ -19,12 +20,13 @@ const handler: RESTHandler = async (
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { title } = schema.parse(req.body);
+  const { title, room } = schema.parse(req.body);
 
   const createdConversation = await prisma.aIConversation.create({
     data: {
       userId: req.user.id,
       title,
+      roomId: room,
     },
   });
 

--- a/RESTAPI/cooking/CreateRecipe.ts
+++ b/RESTAPI/cooking/CreateRecipe.ts
@@ -5,6 +5,7 @@ import { COOKING_CONFIG, GeminiClient } from '../../services/gemini';
 
 const schema = z.object({
   recipeName: z.string().nonempty().max(100),
+  room: z.number(),
 });
 
 const recipeSchema = z.object({
@@ -17,7 +18,7 @@ const handler: RESTHandler = async (req, res, next) => {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { recipeName } = schema.parse(req.body);
+  const { recipeName, room } = schema.parse(req.body);
 
   const recipe = await prisma.recipe.findFirst({
     where: {
@@ -39,6 +40,7 @@ const handler: RESTHandler = async (req, res, next) => {
         name: recipeName,
         ...output,
         userId: req.user.id,
+        roomId: room,
       },
     });
     return res.status(201).json({ recipe });

--- a/RESTAPI/room/CreateRoom.ts
+++ b/RESTAPI/room/CreateRoom.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { RESTHandler, RESTMethods, RESTRoute } from '../../server';
+import prisma from '../../lib/prisma';
+import { sanitizeRoom } from '../../types/room';
+
+const schema = z.object({
+  positions: z
+    .array(z.tuple([z.number(), z.number(), z.number()]))
+    .min(1, 'There must be at least one position')
+    .max(100, 'Too many positions (are you sure this is correct?)'),
+  scale: z.tuple([z.number(), z.number()]),
+  name: z.string().max(100).nonempty(),
+});
+
+const handler: RESTHandler = async (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { positions, scale, name } = schema.parse(req.body);
+
+  const r = await prisma.room.findFirst({
+    where: { name, userId: req.user.id },
+  });
+
+  if (!!r) {
+    return res.status(404).json({ error: 'Room names must be unique' });
+  }
+
+  const room = await prisma.room.create({
+    data: {
+      positions: positions.flat(1),
+      scaleX: scale[0],
+      scaleY: scale[1],
+      name,
+      userId: req.user.id,
+    },
+  });
+  return res.status(201).json({ room: sanitizeRoom(room) });
+};
+
+const CreateRoom: RESTRoute = {
+  method: RESTMethods.POST,
+  path: '/rooms',
+  schema,
+  run: handler,
+  needsAuth: true,
+};
+
+export default CreateRoom;

--- a/RESTAPI/room/DeleteRoom.ts
+++ b/RESTAPI/room/DeleteRoom.ts
@@ -4,7 +4,7 @@ import prisma from '../../lib/prisma';
 import { z } from 'zod';
 
 const schema = z.object({
-  recipe: z.string().nonempty(),
+  name: z.string().nonempty(),
 });
 
 const handler: RESTHandler = async (
@@ -15,27 +15,27 @@ const handler: RESTHandler = async (
   if (!req.user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  const recipe = schema.parse(req.query).recipe;
-  const r = await prisma.recipe.findFirst({
-    where: { name: recipe, userId: req.user.id },
+  const name = schema.parse(req.query).name;
+  const r = await prisma.room.findFirst({
+    where: { name, userId: req.user.id },
   });
   if (!r) {
-    return res.status(404).json({ error: 'Cannot find recipe for user' });
+    return res.status(404).json({ error: 'Cannot find room for user' });
   }
   await prisma.recipe.delete({
     where: {
-      name: recipe,
+      name,
       userId: req.user.id,
       id: r.id,
     },
   });
-  res.status(204).json({ message: 'Recipe deleted successfully' });
+  res.status(204).json({ message: 'Room deleted successfully' });
 };
 
-export const DeleteRecipe = {
+export const DeleteRoom = {
   method: RESTMethods.DELETE,
-  path: '/cook',
+  path: '/rooms',
   run: handler,
   needsAuth: true,
 } as RESTRoute;
-export default DeleteRecipe;
+export default DeleteRoom;

--- a/RESTAPI/room/DeleteRoom.ts
+++ b/RESTAPI/room/DeleteRoom.ts
@@ -4,7 +4,7 @@ import prisma from '../../lib/prisma';
 import { z } from 'zod';
 
 const schema = z.object({
-  name: z.string().nonempty(),
+  anchorId: z.string().nonempty(),
 });
 
 const handler: RESTHandler = async (
@@ -15,16 +15,15 @@ const handler: RESTHandler = async (
   if (!req.user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  const name = schema.parse(req.query).name;
+  const anchorId = schema.parse(req.query).anchorId;
   const r = await prisma.room.findFirst({
-    where: { name, userId: req.user.id },
+    where: { anchorId, userId: req.user.id },
   });
   if (!r) {
     return res.status(404).json({ error: 'Cannot find room for user' });
   }
   await prisma.recipe.delete({
     where: {
-      name,
       userId: req.user.id,
       id: r.id,
     },

--- a/RESTAPI/room/GetRoom.ts
+++ b/RESTAPI/room/GetRoom.ts
@@ -1,0 +1,37 @@
+import { RESTHandler, RESTMethods, RESTRoute } from '../../server';
+import prisma from '../../lib/prisma';
+import { sanitizeRoom } from '../../types/room';
+import z from 'zod';
+
+const schema = z.object({
+  roomID: z.number(),
+});
+
+const handler: RESTHandler = async (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const { roomID } = schema.parse(req.query);
+  const room = await prisma.room.findFirst({
+    where: {
+      userId: req.user.id,
+      id: roomID,
+    },
+  });
+
+  if (!room) {
+    return res.status(404).json({ error: 'Room not found' });
+  }
+
+  return res.status(200).json({ room: sanitizeRoom(room) });
+};
+
+const GetRoom: RESTRoute = {
+  method: RESTMethods.GET,
+  needsAuth: true,
+  path: '/rooms',
+  run: handler,
+};
+
+export default GetRoom;

--- a/RESTAPI/room/GetRoom.ts
+++ b/RESTAPI/room/GetRoom.ts
@@ -4,7 +4,7 @@ import { sanitizeRoom } from '../../types/room';
 import z from 'zod';
 
 const schema = z.object({
-  roomID: z.number(),
+  anchorId: z.string().nonempty(),
 });
 
 const handler: RESTHandler = async (req, res, next) => {
@@ -12,11 +12,11 @@ const handler: RESTHandler = async (req, res, next) => {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { roomID } = schema.parse(req.query);
+  const { anchorId } = schema.parse(req.query);
   const room = await prisma.room.findFirst({
     where: {
       userId: req.user.id,
-      id: roomID,
+      anchorId,
     },
   });
 

--- a/RESTAPI/room/GetRooms.ts
+++ b/RESTAPI/room/GetRooms.ts
@@ -1,0 +1,26 @@
+import { RESTHandler, RESTMethods, RESTRoute } from '../../server';
+import prisma from '../../lib/prisma';
+import { sanitizeRoom } from '../../types/room';
+
+const handler: RESTHandler = async (req, res, next) => {
+  if (!req.user) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  const rooms = await prisma.room.findMany({
+    where: {
+      userId: req.user.id,
+    },
+  });
+
+  return res.status(200).json({ rooms: rooms.map(sanitizeRoom) });
+};
+
+const GetRooms: RESTRoute = {
+  method: RESTMethods.GET,
+  needsAuth: true,
+  path: '/rooms',
+  run: handler,
+};
+
+export default GetRooms;

--- a/RESTAPI/sticky/CreateNote.ts
+++ b/RESTAPI/sticky/CreateNote.ts
@@ -5,6 +5,7 @@ import prisma from '../../lib/prisma';
 const schema = z.object({
   content: z.string().min(1, 'Content is required'),
   metadata: z.record(z.string(), z.any()),
+  room: z.number(),
 });
 
 const handler: RESTHandler = async (req, res, next) => {
@@ -13,12 +14,13 @@ const handler: RESTHandler = async (req, res, next) => {
   }
 
   // Implement logic here
-  const { content, metadata } = schema.parse(req.body);
+  const { content, metadata, room } = schema.parse(req.body);
   const note = await prisma.stickyNote.create({
     data: {
       content,
       metadata,
       userId: req.user.id,
+      roomId: room,
     },
   });
 

--- a/RESTAPI/task/CreateTask.ts
+++ b/RESTAPI/task/CreateTask.ts
@@ -4,6 +4,7 @@ import prisma from '../../lib/prisma';
 
 const schema = z.object({
   task: z.string().nonempty().max(100),
+  room: z.number(),
 });
 
 const handler: RESTHandler = async (req, res, next) => {
@@ -11,11 +12,12 @@ const handler: RESTHandler = async (req, res, next) => {
     return res.status(401).json({ error: 'Unauthorized' });
   }
 
-  const { task: name } = schema.parse(req.body);
+  const { task: name, room } = schema.parse(req.body);
   const taskInfo = await prisma.task.create({
     data: {
       name,
       userId: req.user.id,
+      roomId: room,
     },
   });
 

--- a/prisma/migrations/20250724044059_init/migration.sql
+++ b/prisma/migrations/20250724044059_init/migration.sql
@@ -1,0 +1,49 @@
+/*
+  Warnings:
+
+  - Added the required column `roomId` to the `AIConversation` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `roomId` to the `Recipe` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `roomId` to the `StickyNote` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `roomId` to the `Task` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "AIConversation" ADD COLUMN     "roomId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Recipe" ADD COLUMN     "ingredients" TEXT[],
+ADD COLUMN     "roomId" INTEGER NOT NULL,
+ADD COLUMN     "steps" TEXT[];
+
+-- AlterTable
+ALTER TABLE "StickyNote" ADD COLUMN     "roomId" INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "roomId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Room" (
+    "id" SERIAL NOT NULL,
+    "positions" DOUBLE PRECISION[],
+    "userId" INTEGER NOT NULL,
+    "scaleX" DOUBLE PRECISION NOT NULL,
+    "scaleY" DOUBLE PRECISION NOT NULL,
+    "name" TEXT NOT NULL,
+
+    CONSTRAINT "Room_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "AIConversation" ADD CONSTRAINT "AIConversation_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Recipe" ADD CONSTRAINT "Recipe_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "StickyNote" ADD CONSTRAINT "StickyNote_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Room"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Room" ADD CONSTRAINT "Room_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250724051640_fix_room/migration.sql
+++ b/prisma/migrations/20250724051640_fix_room/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `positions` on the `Room` table. All the data in the column will be lost.
+  - You are about to drop the column `scaleY` on the `Room` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[anchorId]` on the table `Room` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[name]` on the table `Room` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `anchorId` to the `Room` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `positionX` to the `Room` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `positionY` to the `Room` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `positionZ` to the `Room` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `rotation` to the `Room` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `scaleZ` to the `Room` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Room" DROP COLUMN "positions",
+DROP COLUMN "scaleY",
+ADD COLUMN     "anchorId" TEXT NOT NULL,
+ADD COLUMN     "positionX" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "positionY" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "positionZ" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "rotation" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "scaleZ" DOUBLE PRECISION NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Room_anchorId_key" ON "Room"("anchorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Room_name_key" ON "Room"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,15 +81,19 @@ model StickyNote {
 }
 
 model Room {
-  id              Int              @id @default(autoincrement())
-  positions       Float[]
-  userId          Int
-  user            User             @relation(fields: [userId], references: [id])
-  scaleX          Float
-  scaleY          Float
-  name            String
-  AIConversations AIConversation[]
-  Recipes         Recipe[]
-  Task            Task[]
-  StickyNotes     StickyNote[]
+  id             Int              @id @default(autoincrement())
+  anchorId       String           @unique
+  positionX      Float
+  positionY      Float
+  positionZ      Float
+  userId         Int
+  user           User             @relation(fields: [userId], references: [id])
+  scaleX         Float
+  scaleZ         Float
+  rotation       Float
+  name           String           @unique
+  AIConversation AIConversation[]
+  Recipe         Recipe[]
+  Task           Task[]
+  StickyNote     StickyNote[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   Recipes         Recipe[]
   Task            Task[]
   StickyNotes     StickyNote[]
+  Rooms           Room[]
 }
 
 model AIConversation {
@@ -25,6 +26,8 @@ model AIConversation {
   updatedAt DateTime    @updatedAt
   userId    Int
   user      User        @relation(fields: [userId], references: [id])
+  roomId    Int
+  room      Room        @relation(fields: [roomId], references: [id])
   title     String
   AIMessage AIMessage[]
 }
@@ -45,6 +48,8 @@ model Recipe {
   updatedAt   DateTime @updatedAt
   userId      Int
   user        User     @relation(fields: [userId], references: [id])
+  roomId      Int
+  room        Room     @relation(fields: [roomId], references: [id])
   name        String
   ingredients String[]
   steps       String[]
@@ -57,6 +62,8 @@ model Task {
   updatedAt DateTime @updatedAt
   userId    Int
   user      User     @relation(fields: [userId], references: [id])
+  roomId    Int
+  room      Room     @relation(fields: [roomId], references: [id])
   name      String
   completed Boolean  @default(false)
 }
@@ -67,6 +74,22 @@ model StickyNote {
   updatedAt DateTime @updatedAt
   userId    Int
   user      User     @relation(fields: [userId], references: [id])
+  roomId    Int
+  room      Room     @relation(fields: [roomId], references: [id])
   content   String
   metadata  Json
+}
+
+model Room {
+  id              Int              @id @default(autoincrement())
+  positions       Float[]
+  userId          Int
+  user            User             @relation(fields: [userId], references: [id])
+  scaleX          Float
+  scaleY          Float
+  name            String
+  AIConversations AIConversation[]
+  Recipes         Recipe[]
+  Task            Task[]
+  StickyNotes     StickyNote[]
 }

--- a/types/room.ts
+++ b/types/room.ts
@@ -1,0 +1,42 @@
+export type SanitizedRoom = {
+  positions: [number, number, number][];
+  scale: [number, number];
+  widgets?: {
+    aiConversations: number[];
+    recipes: number[];
+    task: number[];
+    stickyNotes: number[];
+  };
+  name: string;
+};
+
+type PrismaRoom = {
+  name: string;
+  id: number;
+  userId: number;
+  positions: number[];
+  scaleX: number;
+  scaleY: number;
+};
+
+export const sanitizeRoom = (unsanitized: PrismaRoom): SanitizedRoom => {
+  if (unsanitized.positions.length % 3 != 0) {
+    throw Error(`Unsanitized room has invalid positions array`);
+  }
+
+  return {
+    name: unsanitized.name,
+    scale: [unsanitized.scaleX, unsanitized.scaleY],
+    positions: unsanitized.positions
+      .map((_, i) =>
+        i % 3 == 0
+          ? ([
+              unsanitized.positions[i],
+              unsanitized.positions[i + 1],
+              unsanitized.positions[i + 2],
+            ] as [number, number, number])
+          : undefined,
+      )
+      .filter((v) => !!v),
+  };
+};

--- a/types/room.ts
+++ b/types/room.ts
@@ -24,19 +24,19 @@ export const sanitizeRoom = (unsanitized: PrismaRoom): SanitizedRoom => {
     throw Error(`Unsanitized room has invalid positions array`);
   }
 
+  const positions: [number, number, number][] = [];
+
+  for (let i = 0; i < unsanitized.positions.length; i += 3) {
+    positions.push([
+      unsanitized.positions[i],
+      unsanitized.positions[i + 1],
+      unsanitized.positions[i + 2],
+    ]);
+  }
+
   return {
     name: unsanitized.name,
     scale: [unsanitized.scaleX, unsanitized.scaleY],
-    positions: unsanitized.positions
-      .map((_, i) =>
-        i % 3 == 0
-          ? ([
-              unsanitized.positions[i],
-              unsanitized.positions[i + 1],
-              unsanitized.positions[i + 2],
-            ] as [number, number, number])
-          : undefined,
-      )
-      .filter((v) => !!v),
+    positions,
   };
 };

--- a/types/room.ts
+++ b/types/room.ts
@@ -1,5 +1,5 @@
 export type SanitizedRoom = {
-  positions: [number, number, number][];
+  position: [number, number, number];
   scale: [number, number];
   widgets?: {
     aiConversations: number[];
@@ -8,35 +8,29 @@ export type SanitizedRoom = {
     stickyNotes: number[];
   };
   name: string;
+  anchorId: string;
+  rotation: number;
 };
 
 type PrismaRoom = {
   name: string;
+  anchorId: string;
   id: number;
   userId: number;
-  positions: number[];
+  positionX: number;
+  positionY: number;
+  positionZ: number;
+  rotation: number;
   scaleX: number;
-  scaleY: number;
+  scaleZ: number;
 };
 
 export const sanitizeRoom = (unsanitized: PrismaRoom): SanitizedRoom => {
-  if (unsanitized.positions.length % 3 != 0) {
-    throw Error(`Unsanitized room has invalid positions array`);
-  }
-
-  const positions: [number, number, number][] = [];
-
-  for (let i = 0; i < unsanitized.positions.length; i += 3) {
-    positions.push([
-      unsanitized.positions[i],
-      unsanitized.positions[i + 1],
-      unsanitized.positions[i + 2],
-    ]);
-  }
-
   return {
     name: unsanitized.name,
-    scale: [unsanitized.scaleX, unsanitized.scaleY],
-    positions,
+    scale: [unsanitized.scaleX, unsanitized.scaleZ],
+    position: [unsanitized.positionX, unsanitized.positionY, unsanitized.positionZ],
+    anchorId: unsanitized.anchorId,
+    rotation: unsanitized.rotation,
   };
 };


### PR DESCRIPTION
## Notes
- Added room types to backend
- Linked existing widgets to rooms
- Adds sanitization to make client-size processing of rooms easier
  - This is because prisma doesn't have tuple support
- Fixed naming issue in recipes
- Updated creation endpoints for all widgets
- Created endpoints for Creation, Deletion, and Retrieval of rooms
## TODOs/Questions
- [x] Generate migrations (idk how)
- [x] ~~Test with Jesse~~